### PR TITLE
Tests

### DIFF
--- a/test.js
+++ b/test.js
@@ -2,6 +2,8 @@
 
 const generate = require('./index')
 
+const trailingSpace = ' '
+
 it('Guards', function () {
   const inputs = [null, {}, undefined]
   inputs.forEach(input => {
@@ -11,10 +13,162 @@ it('Guards', function () {
 
 it('Simple string', function () {
   const schema = { type: 'string' }
-  const expected = '/**  * Represents a undefined object  * @name   *'
-  expect(process(schema)).toEqual(expected)
+  const expected = `/**
+  * Represents a undefined object
+  * @name${trailingSpace}
+  *
+`
+  expect(generate(schema)).toEqual(expected)
 })
 
-function process (input) {
-  return generate(input).replace(/\n/gm, '')
-}
+it('Object with properties', function () {
+  const schema = {
+    type: 'object',
+    properties: {
+      aStringProp: {
+        type: 'string'
+      },
+      anObjectProp: {
+        type: 'object',
+        properties: {
+          aNestedProp: {
+            type: 'boolean'
+          }
+        }
+      },
+      nullableType: {
+        type: ['string', 'null']
+      },
+      multipleTypes: {
+        type: ['string', 'number']
+      },
+      enumProp: {
+        enum: ['hello', 'world']
+      }
+    }
+  }
+  const expected = `/**
+  * Represents a undefined object
+  * @name${trailingSpace}
+  *
+  * @property {string} [aStringProp] - ${trailingSpace}
+  * @property {object} [anObjectProp] - ${trailingSpace}
+  * @property {boolean} [.aNestedProp] - ${trailingSpace}
+  * @property {?string} [nullableType] - ${trailingSpace}
+  * @property {string|number} [multipleTypes] - ${trailingSpace}
+  * @property {enum} [enumProp] - ${trailingSpace}
+  */
+`
+  expect(generate(schema)).toEqual(expected)
+})
+
+it('Schema with `$ref`', function () {
+  const schema = {
+    $defs: { // New name for `definitions`
+      definitionType: {
+        type: 'number'
+      }
+    },
+    type: 'object',
+    properties: {
+      aNumberProp: {
+        $ref: '#/$defs/definitionType'
+      }
+    }
+  }
+  const expected = `/**
+  * Represents a undefined object
+  * @name${trailingSpace}
+  *
+  * @property {number} [aNumberProp] - ${trailingSpace}
+  */
+`
+  expect(generate(schema)).toEqual(expected)
+})
+
+it('Object with properties and `required`', function () {
+  const schema = {
+    type: 'object',
+    properties: {
+      anObjectProp: {
+        type: 'object',
+        required: ['aNestedProp'],
+        properties: {
+          aNestedProp: {
+            type: 'boolean'
+          },
+          anotherNestedProp: {
+            type: 'number'
+          }
+        }
+      }
+    }
+  }
+  const expected = `/**
+  * Represents a undefined object
+  * @name${trailingSpace}
+  *
+  * @property {object} [anObjectProp] - ${trailingSpace}
+  * @property {boolean} .aNestedProp - ${trailingSpace}
+  * @property {number} [.anotherNestedProp] - ${trailingSpace}
+  */
+`
+  expect(generate(schema)).toEqual(expected)
+})
+
+it('Object with untyped property', function () {
+  const schema = {
+    type: 'object',
+    properties: {
+      anObjectProp: {
+        type: 'object',
+        properties: {
+          aNestedProp: {
+          },
+          anotherNestedProp: {
+            type: 'number'
+          }
+        }
+      }
+    }
+  }
+  const expected = `/**
+  * Represents a undefined object
+  * @name${trailingSpace}
+  *
+  * @property {object} [anObjectProp] - ${trailingSpace}
+  * @property {ANestedProp} [.aNestedProp] - ${trailingSpace}
+  * @property {number} [.anotherNestedProp] - ${trailingSpace}
+  */
+`
+  expect(generate(schema)).toEqual(expected)
+})
+
+it('Object with properties and `ignore` option', function () {
+  const schema = {
+    type: 'object',
+    properties: {
+      aStringProp: {
+        type: 'string'
+      },
+      anObjectProp: {
+        type: 'object',
+        properties: {
+          aNestedProp: {
+            type: 'boolean'
+          }
+        }
+      }
+    }
+  }
+  const expected = `/**
+  * Represents a undefined object
+  * @name${trailingSpace}
+  *
+  * @property {string} [aStringProp] - ${trailingSpace}
+  */
+`
+  expect(generate(schema, {
+    ignore: ['anObjectProp']
+  })).toEqual(expected)
+})


### PR DESCRIPTION
Builds on #3 . If you have changes for #3, I can amend and rebase this PR on top of the changes.

- Fix: `root` was the old Node name for`global`; fixed to refer to root schema
- Refactoring: Remove unreachable `writeParam` `type` default
- Testing: Add tests for objects with properties and a schema with `$ref`;
    `ignore` option; `required`, untyped

This brings the project to 100% coverage (as can be seen by running the `test` or `nyc` script).