### PR TITLE
Drop extra space

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function generate (schema, options = {}) {
   return jsdoc
 }
 
-function processProperties (schema, rootSchema, nested, options = {}) {
+function processProperties (schema, rootSchema, nested, options) {
   const props = json.get(schema, '/properties')
   const required = json.has(schema, '/required') ? json.get(schema, '/required') : []
 
@@ -39,7 +39,7 @@ function processProperties (schema, rootSchema, nested, options = {}) {
 
       if (props[property].type === 'object' && props[property].properties) {
         text += writeParam('object', prefix + property, props[property].description, true, options)
-        text += processProperties(props[property], rootSchema, true)
+        text += processProperties(props[property], rootSchema, true, options)
       } else {
         const optional = !required.includes(property)
         const type = getType(props[property], rootSchema) || upperFirst(property)

--- a/index.js
+++ b/index.js
@@ -38,12 +38,12 @@ function processProperties (schema, rootSchema, nested, options = {}) {
       const prefix = nested ? '.' : ''
 
       if (props[property].type === 'object' && props[property].properties) {
-        text += writeParam('object', prefix + property, props[property].description, true)
+        text += writeParam('object', prefix + property, props[property].description, true, options)
         text += processProperties(props[property], rootSchema, true)
       } else {
         const optional = !required.includes(property)
         const type = getType(props[property], rootSchema) || upperFirst(property)
-        text += writeParam(type, prefix + property, props[property].description, optional)
+        text += writeParam(type, prefix + property, props[property].description, optional, options)
       }
     }
   }
@@ -59,9 +59,11 @@ function writeDescription (schema) {
 `
 }
 
-function writeParam (type, field, description = '', optional) {
+function writeParam (type, field, description = '', optional, options) {
   const fieldTemplate = optional ? `[${field}]` : field
-  return `  * @property {${type}} ${fieldTemplate} - ${description}\n`
+  return `  * @property {${type}} ${fieldTemplate}${
+    !description && options.descriptionPlaceholder === false ? '' : ` - ${description}`
+  }\n`
 }
 
 function getType (schema, rootSchema) {

--- a/index.js
+++ b/index.js
@@ -62,7 +62,11 @@ function writeDescription (schema) {
 function writeParam (type, field, description = '', optional, options) {
   const fieldTemplate = optional ? `[${field}]` : field
   return `  * @property {${type}} ${fieldTemplate}${
-    !description && options.descriptionPlaceholder === false ? '' : ` - ${description}`
+    !description && options.descriptionPlaceholder === false
+      ? ''
+      : options.hyphenatedDescriptions === false
+        ? ` ${description}`
+        : ` - ${description}`
   }\n`
 }
 

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function writeDescription (schema) {
 
 function writeParam (type, field, description = '', optional) {
   const fieldTemplate = optional ? `[${field}]` : field
-  return `  * @property {${type}} ${fieldTemplate} - ${description} \n`
+  return `  * @property {${type}} ${fieldTemplate} - ${description}\n`
 }
 
 function getType (schema, rootSchema) {

--- a/test.js
+++ b/test.js
@@ -63,6 +63,50 @@ it('Object with properties', function () {
   expect(generate(schema)).toEqual(expected)
 })
 
+it('Object with properties (with false `descriptionPlaceholder`)', function () {
+  const schema = {
+    type: 'object',
+    properties: {
+      aStringProp: {
+        type: 'string'
+      },
+      anObjectProp: {
+        type: 'object',
+        properties: {
+          aNestedProp: {
+            description: 'Boolean desc.',
+            type: 'boolean'
+          }
+        }
+      },
+      nullableType: {
+        type: ['string', 'null']
+      },
+      multipleTypes: {
+        type: ['string', 'number']
+      },
+      enumProp: {
+        enum: ['hello', 'world']
+      }
+    }
+  }
+  const expected = `/**
+  * Represents a undefined object
+  * @name${trailingSpace}
+  *
+  * @property {string} [aStringProp]
+  * @property {object} [anObjectProp]
+  * @property {boolean} [.aNestedProp] - Boolean desc.
+  * @property {?string} [nullableType]
+  * @property {string|number} [multipleTypes]
+  * @property {enum} [enumProp]
+  */
+`
+  expect(generate(schema, {
+    descriptionPlaceholder: false
+  })).toEqual(expected)
+})
+
 it('Schema with `$ref`', function () {
   const schema = {
     $defs: { // New name for `definitions`

--- a/test.js
+++ b/test.js
@@ -32,6 +32,7 @@ it('Object with properties', function () {
         type: 'object',
         properties: {
           aNestedProp: {
+            description: 'Boolean desc.',
             type: 'boolean'
           }
         }
@@ -51,12 +52,12 @@ it('Object with properties', function () {
   * Represents a undefined object
   * @name${trailingSpace}
   *
-  * @property {string} [aStringProp] - ${trailingSpace}
-  * @property {object} [anObjectProp] - ${trailingSpace}
-  * @property {boolean} [.aNestedProp] - ${trailingSpace}
-  * @property {?string} [nullableType] - ${trailingSpace}
-  * @property {string|number} [multipleTypes] - ${trailingSpace}
-  * @property {enum} [enumProp] - ${trailingSpace}
+  * @property {string} [aStringProp] -${trailingSpace}
+  * @property {object} [anObjectProp] -${trailingSpace}
+  * @property {boolean} [.aNestedProp] - Boolean desc.
+  * @property {?string} [nullableType] -${trailingSpace}
+  * @property {string|number} [multipleTypes] -${trailingSpace}
+  * @property {enum} [enumProp] -${trailingSpace}
   */
 `
   expect(generate(schema)).toEqual(expected)
@@ -80,7 +81,7 @@ it('Schema with `$ref`', function () {
   * Represents a undefined object
   * @name${trailingSpace}
   *
-  * @property {number} [aNumberProp] - ${trailingSpace}
+  * @property {number} [aNumberProp] -${trailingSpace}
   */
 `
   expect(generate(schema)).toEqual(expected)
@@ -108,9 +109,9 @@ it('Object with properties and `required`', function () {
   * Represents a undefined object
   * @name${trailingSpace}
   *
-  * @property {object} [anObjectProp] - ${trailingSpace}
-  * @property {boolean} .aNestedProp - ${trailingSpace}
-  * @property {number} [.anotherNestedProp] - ${trailingSpace}
+  * @property {object} [anObjectProp] -${trailingSpace}
+  * @property {boolean} .aNestedProp -${trailingSpace}
+  * @property {number} [.anotherNestedProp] -${trailingSpace}
   */
 `
   expect(generate(schema)).toEqual(expected)
@@ -136,9 +137,9 @@ it('Object with untyped property', function () {
   * Represents a undefined object
   * @name${trailingSpace}
   *
-  * @property {object} [anObjectProp] - ${trailingSpace}
-  * @property {ANestedProp} [.aNestedProp] - ${trailingSpace}
-  * @property {number} [.anotherNestedProp] - ${trailingSpace}
+  * @property {object} [anObjectProp] -${trailingSpace}
+  * @property {ANestedProp} [.aNestedProp] -${trailingSpace}
+  * @property {number} [.anotherNestedProp] -${trailingSpace}
   */
 `
   expect(generate(schema)).toEqual(expected)
@@ -165,7 +166,7 @@ it('Object with properties and `ignore` option', function () {
   * Represents a undefined object
   * @name${trailingSpace}
   *
-  * @property {string} [aStringProp] - ${trailingSpace}
+  * @property {string} [aStringProp] -${trailingSpace}
   */
 `
   expect(generate(schema, {

--- a/test.js
+++ b/test.js
@@ -107,6 +107,50 @@ it('Object with properties (with false `descriptionPlaceholder`)', function () {
   })).toEqual(expected)
 })
 
+it('Object with properties (with false `hyphenatedDescriptions`)', function () {
+  const schema = {
+    type: 'object',
+    properties: {
+      aStringProp: {
+        type: 'string'
+      },
+      anObjectProp: {
+        type: 'object',
+        properties: {
+          aNestedProp: {
+            description: 'Boolean desc.',
+            type: 'boolean'
+          }
+        }
+      },
+      nullableType: {
+        type: ['string', 'null']
+      },
+      multipleTypes: {
+        type: ['string', 'number']
+      },
+      enumProp: {
+        enum: ['hello', 'world']
+      }
+    }
+  }
+  const expected = `/**
+  * Represents a undefined object
+  * @name${trailingSpace}
+  *
+  * @property {string} [aStringProp]${trailingSpace}
+  * @property {object} [anObjectProp]${trailingSpace}
+  * @property {boolean} [.aNestedProp] Boolean desc.
+  * @property {?string} [nullableType]${trailingSpace}
+  * @property {string|number} [multipleTypes]${trailingSpace}
+  * @property {enum} [enumProp]${trailingSpace}
+  */
+`
+  expect(generate(schema, {
+    hyphenatedDescriptions: false
+  })).toEqual(expected)
+})
+
 it('Schema with `$ref`', function () {
   const schema = {
     $defs: { // New name for `definitions`


### PR DESCRIPTION
I put these as separate commits in case you want them as separate PRs, but they are related in that they impact trailing spaces for descriptions (or the hyphens therewith).

Fixes 4.ii, 4.iii, and 5 in #6.

- Avoids adding space and hyphen when new `descriptionPlaceholder` option is set to `false`
- Drops extra trailing space (also adds a description to a test `@property`)
- Add `hyphenatedDescription` option which when `false` will avoid auto-adding hyphens to descriptions

(`trailingSpace` variable remaining in tests is to make clear the remaining single
trailing space is intentional and also to avoid IDEs stripping)