### PR TITLE
Description options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,7 @@ jsdoc(schema);
 ```js
 /**
   * Represents a Person object
+  * @typedef {object}
   *
   * @property {string} name - A person's name
   * @property {integer} [age] - A person's age

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Useful when you already have a JSON Schema and want to document the types you wa
 const jsdoc = require('json-schema-to-jsdoc');
 
 const schema = {
-  "id": "Person",
+  "title": "Person",
   "type": "object",
   "properties": {
     "name": {"type": "string", "description": "A person's name"},

--- a/test.js
+++ b/test.js
@@ -14,11 +14,99 @@ it('Guards', function () {
 it('Simple string', function () {
   const schema = { type: 'string' }
   const expected = `/**
-  * Represents a undefined object
-  * @name${trailingSpace}
-  *
+  * Represents a string
+  * @typedef {string}
+  */
 `
   expect(generate(schema)).toEqual(expected)
+})
+
+it('Simple object with `autoDescribe`: false', function () {
+  const schema = {
+    type: 'object'
+  }
+  const expected = `/**
+  *
+  * @typedef {object}
+  */
+`
+  expect(generate(schema, {
+    autoDescribe: false
+  })).toEqual(expected)
+})
+
+it('Simple object with `types`: false', function () {
+  const schema = {
+    type: 'object'
+  }
+  const expected = `/**
+  * Represents an object
+  * @typedef
+  */
+`
+  expect(generate(schema, {
+    types: false
+  })).toEqual(expected)
+})
+
+it('Simple object with empty string `types`', function () {
+  const schema = {
+    type: 'object'
+  }
+  const expected = `/**
+  * Represents an object
+  * @typedef {}
+  */
+`
+  expect(generate(schema, {
+    types: {
+      object: ''
+    }
+  })).toEqual(expected)
+})
+
+it('Simple object with `types`', function () {
+  const schema = {
+    type: 'object'
+  }
+  const expected = `/**
+  * Represents an object
+  * @typedef {PlainObject}
+  */
+`
+  expect(generate(schema, {
+    types: {
+      object: 'PlainObject'
+    }
+  })).toEqual(expected)
+})
+
+it('Simple object with title', function () {
+  const schema = {
+    title: 'special',
+    type: 'object'
+  }
+  const expected = `/**
+  * Represents a special object
+  * @typedef {object} Special
+  */
+`
+  expect(generate(schema)).toEqual(expected)
+})
+
+it('Simple object with title and `capitalizeTitle`: false', function () {
+  const schema = {
+    title: 'special',
+    type: 'object'
+  }
+  const expected = `/**
+  * Represents a special object
+  * @typedef {object} special
+  */
+`
+  expect(generate(schema, {
+    capitalizeTitle: false
+  })).toEqual(expected)
 })
 
 it('Object with properties', function () {
@@ -49,8 +137,8 @@ it('Object with properties', function () {
     }
   }
   const expected = `/**
-  * Represents a undefined object
-  * @name${trailingSpace}
+  * Represents an object
+  * @typedef {object}
   *
   * @property {string} [aStringProp] -${trailingSpace}
   * @property {object} [anObjectProp] -${trailingSpace}
@@ -91,8 +179,8 @@ it('Object with properties (with false `descriptionPlaceholder`)', function () {
     }
   }
   const expected = `/**
-  * Represents a undefined object
-  * @name${trailingSpace}
+  * Represents an object
+  * @typedef {object}
   *
   * @property {string} [aStringProp]
   * @property {object} [anObjectProp]
@@ -135,8 +223,8 @@ it('Object with properties (with false `hyphenatedDescriptions`)', function () {
     }
   }
   const expected = `/**
-  * Represents a undefined object
-  * @name${trailingSpace}
+  * Represents an object
+  * @typedef {object}
   *
   * @property {string} [aStringProp]${trailingSpace}
   * @property {object} [anObjectProp]${trailingSpace}
@@ -166,8 +254,8 @@ it('Schema with `$ref`', function () {
     }
   }
   const expected = `/**
-  * Represents a undefined object
-  * @name${trailingSpace}
+  * Represents an object
+  * @typedef {object}
   *
   * @property {number} [aNumberProp] -${trailingSpace}
   */
@@ -194,8 +282,8 @@ it('Object with properties and `required`', function () {
     }
   }
   const expected = `/**
-  * Represents a undefined object
-  * @name${trailingSpace}
+  * Represents an object
+  * @typedef {object}
   *
   * @property {object} [anObjectProp] -${trailingSpace}
   * @property {boolean} .aNestedProp -${trailingSpace}
@@ -222,8 +310,8 @@ it('Object with untyped property', function () {
     }
   }
   const expected = `/**
-  * Represents a undefined object
-  * @name${trailingSpace}
+  * Represents an object
+  * @typedef {object}
   *
   * @property {object} [anObjectProp] -${trailingSpace}
   * @property {ANestedProp} [.aNestedProp] -${trailingSpace}
@@ -251,8 +339,8 @@ it('Object with properties and `ignore` option', function () {
     }
   }
   const expected = `/**
-  * Represents a undefined object
-  * @name${trailingSpace}
+  * Represents an object
+  * @typedef {object}
   *
   * @property {string} [aStringProp] -${trailingSpace}
   */


### PR DESCRIPTION
Description options.

I know you said you wanted the space change next (and that is part of this PR), and also as I recall wanted atomic PRs, but these were kind of interrelated. I can close if there are too many things in here, but was wondering if you might look at the tests to see whether you like the direction for the features?

- Add closing `/` on jsdoc block when object has no properties
- Add `autoDescribe` option which if `false` will avoid "Represents a..." text (no. 1 of #6)
- Change from using `schema.id` within "Represents a ... object" to `schema.title` (and after tag name and any type) (no. 2 of #6)
- If no `schema.title` is present (and `autoDescribe` is not `false`), change "a" to "an" for types like object
- Avoids extra space if `autoDescribe` is false (or `schema.description` is an empty string)
- Change from `@name` to `@typedef` by default, but add new option `objectTagName` to override (no. 3 of #6)
- Add option `types` which unless `false` will add curly brackets;
    if `types` matched to the `schema.type` as key is the empty string, no type will be set but will otherwise be
    value of `types[schema.type]` option, defaulting to `schema.type`;  (no. 3.i of #6)
- Avoid empty space if title is empty  (no .4.i of #6)
- Add `capitalizeTitle` option which if `false` will avoid capitalizing the title