### PR TITLE
Schema description

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,12 @@ function processProperties (schema, rootSchema, nested, options) {
 }
 
 function writeDescription (schema, options) {
-  const description = options.autoDescribe === false ? '' : generateDescription(schema.title, schema.type)
+  let { description } = schema
+  if (description === undefined) {
+    description = options.autoDescribe === false ? '' : generateDescription(schema.title, schema.type)
+  } else {
+    description = ` ${description}`
+  }
   const typeMatch = options.types && options.types[schema.type]
 
   let type

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",
-    "test": "jest",
+    "test": "jest --coverage",
     "example": "node example.js",
     "postexample": "jsdoc docs.js"
   },

--- a/test.js
+++ b/test.js
@@ -21,6 +21,16 @@ it('Simple string', function () {
   expect(generate(schema)).toEqual(expected)
 })
 
+it('Simple string with description', function () {
+  const schema = { type: 'string', description: 'String description' }
+  const expected = `/**
+  * String description
+  * @typedef {string}
+  */
+`
+  expect(generate(schema)).toEqual(expected)
+})
+
 it('Simple object with `autoDescribe`: false', function () {
   const schema = {
     type: 'object'


### PR DESCRIPTION
Builds on #9.

Nice catch on need for article distinction for `schema.title`.

I did want to keep the ability for `schema.description` to be used whenever available, however, which this restores, if that's ok.