### PR TITLE
Property types

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,15 +2,17 @@
 
 const json = require('json-pointer')
 
-const defaultPropertyType = '*'
-function getDefaultPropertyType (options, property) {
-  if (property !== undefined && options.propertyNameAsType) {
-    return options.capitalizeProperty ? upperFirst(property) : property
+const fallbackPropertyType = '*'
+function getDefaultPropertyType ({
+  propertyNameAsType, capitalizeProperty, defaultPropertyType
+}, property) {
+  if (property !== undefined && propertyNameAsType) {
+    return capitalizeProperty ? upperFirst(property) : property
   }
-  if (options.defaultPropertyType === false) {
-    return null
+  if (defaultPropertyType === null || defaultPropertyType === '') {
+    return defaultPropertyType
   }
-  return options.defaultPropertyType || defaultPropertyType
+  return defaultPropertyType || fallbackPropertyType
 }
 
 module.exports = generate
@@ -100,7 +102,7 @@ function writeDescription (schema, options) {
   const typeMatch = options.types && options.types[schema.type]
 
   let type
-  if (options.types === false) {
+  if (options.types === null) {
     type = ''
   } else {
     type = ` {${

--- a/readme.md
+++ b/readme.md
@@ -97,16 +97,29 @@ jsdoc(schema, {
 - `autoDescribe: boolean` - Adds a description
     (`"Represents a/n [<title> ]<type>"`) when the schema has no
     `description`. Defaults to `false`.
-- `capitalizeTitle: boolean` - If a schema `title` is present, capitalizes the schema's `title` in the output of
-    `@typedef [{type}] title`. Defaults to `false.`
+- `capitalizeTitle: boolean` - If a schema `title` is present, capitalizes the
+    schema's `title` in the output of `@typedef {myType} title`
+- `capitalizeProperty: boolean` - When `propertyNameAsType` is `true`,
+    capitalizes the property-as-type, i.e., `MyTitle` in
+    `@property {MyTitle} myTitle`. Defaults to `false.`
+- `defaultPropertyType: string|false` - Used when no schema type is present.
+    If set to a string, that string will be used (e.g., "any", "JSON",
+    "external:JSON"). Note that jsdoc recommends `*` for any, while TypeScript
+    uses "any". If one defines one's own "JSON" type, one could use that to
+    clarify that only JSON types are used. If `defaultPropertyType` is set to
+    `false`, will avoid any type brackets or type being added. Defaults to
+    the string `*`.
 - `descriptionPlaceholder: boolean` - If `false` and there is no `description`
     for the object `@property`, this will avoid a hyphen or even a space for
-    `{description}` within `@property {name}{description}`. Defaults to `false`.
-- `addDescriptionLineBreak: boolean` - Inserts an empty line when `autoDescribe` is `false` and the schema
-    `description` is empty. Defaults to `false`.
-- `hyphenatedDescriptions: boolean` - Inserts a hyphen + space in the `{description}` portion of
-    `@property {name}{description}` (will add a space, however, unless
-    `descriptionPlaceholder` is `false`). Defaults to `false`.
+    `{description}` within `@property {name}{description}`. Defaults to
+    `false`.
+- `addDescriptionLineBreak: boolean` - Inserts an empty line when
+    `autoDescribe` is `false` and the schema `description` is empty. Defaults
+    to `false`.
+- `hyphenatedDescriptions: boolean` - Inserts a hyphen + space in the
+    `{description}` portion of `@property {name}{description}` (will add a
+    space, however, unless `descriptionPlaceholder` is `false`). Defaults to
+    `false`.
 - `ignore: string[]` - Property names to ignore adding to output. Defaults to
     empty array.
 - `indent: number` - How many of `indentChar` to precede each line. Defaults
@@ -115,6 +128,9 @@ jsdoc(schema, {
 - `indentChar: string` - Character to use when `indent` is set (e.g., a tab or
     space). Defaults to a space.
 - `objectTagName: string` - Tag name to use for objects. Defaults to `typedef`.
+- `propertyNameAsType: boolean` -  Indicates that the property name (for
+    objects) should be used as the type name (optionally capitalized with
+    `capitalizeProperty`).
 - `types: boolean|{[schemaType: string]: string}` - Used to determine output of
     curly-bracketed type content within `@typedef {...}`.
     If `types` is `false`, no curly brackets or type content will be shown

--- a/readme.md
+++ b/readme.md
@@ -98,17 +98,18 @@ jsdoc(schema, {
     (`"Represents a/n [<title> ]<type>"`) when the schema has no
     `description`. Defaults to `false`.
 - `capitalizeTitle: boolean` - If a schema `title` is present, capitalizes the
-    schema's `title` in the output of `@typedef {myType} title`
+    schema's `title` in the output of `@typedef {myType} title`. Defaults to
+    `false`.
 - `capitalizeProperty: boolean` - When `propertyNameAsType` is `true`,
     capitalizes the property-as-type, i.e., `MyTitle` in
     `@property {MyTitle} myTitle`. Defaults to `false.`
-- `defaultPropertyType: string|false` - Used when no schema type is present.
+- `defaultPropertyType: string|null` - Used when no schema type is present.
     If set to a string, that string will be used (e.g., "any", "JSON",
     "external:JSON"). Note that jsdoc recommends `*` for any, while TypeScript
     uses "any". If one defines one's own "JSON" type, one could use that to
     clarify that only JSON types are used. If `defaultPropertyType` is set to
-    `false`, will avoid any type brackets or type being added. Defaults to
-    the string `*`.
+    `null`, will avoid any type brackets or type being added. Defaults to
+    `*`.
 - `descriptionPlaceholder: boolean` - If `false` and there is no `description`
     for the object `@property`, this will avoid a hyphen or even a space for
     `{description}` within `@property {name}{description}`. Defaults to
@@ -130,10 +131,10 @@ jsdoc(schema, {
 - `objectTagName: string` - Tag name to use for objects. Defaults to `typedef`.
 - `propertyNameAsType: boolean` -  Indicates that the property name (for
     objects) should be used as the type name (optionally capitalized with
-    `capitalizeProperty`).
-- `types: boolean|{[schemaType: string]: string}` - Used to determine output of
+    `capitalizeProperty`). Defaults to `false`.
+- `types: null|{[schemaType: string]: string}` - Used to determine output of
     curly-bracketed type content within `@typedef {...}`.
-    If `types` is `false`, no curly brackets or type content will be shown
+    If `types` is `null`, no curly brackets or type content will be shown
     with the `@typedef` at all. If the schema `type` matches a property in the
     object map, and it maps to the empty string, an empty `{}` will result.
     Otherwise, if there is a `type` match, that string will be used as the

--- a/test.js
+++ b/test.js
@@ -403,7 +403,7 @@ describe('option: `autoDescriptionLineBreak`', () => {
 })
 
 describe('option: `types`', () => {
-  it('Simple object with `types`: false', function () {
+  it('Simple object with `types`: null', function () {
     const schema = {
       type: 'object'
     }
@@ -412,7 +412,7 @@ describe('option: `types`', () => {
  */
 `
     expect(generate(schema, {
-      types: false
+      types: null
     })).toEqual(expected)
   })
   it('Simple object with empty string `types`', function () {
@@ -781,7 +781,7 @@ describe('option `defaultPropertyType`', function () {
  */
 `
     expect(generate(schema, {
-      defaultPropertyType: false
+      defaultPropertyType: null
     })).toEqual(expected)
   })
 })

--- a/test.js
+++ b/test.js
@@ -182,7 +182,7 @@ describe('Schemas with properties', () => {
     const expected = `/**
  * @typedef {object}
  * @property {object} [anObjectProp]
- * @property {ANestedProp} [anObjectProp.aNestedProp]
+ * @property {*} [anObjectProp.aNestedProp]
  * @property {number} [anObjectProp.anotherNestedProp]
  */
 `
@@ -445,6 +445,67 @@ describe('option: `types`', () => {
   })
 })
 
+describe('option: `propertyNameAsType`', function () {
+  it('Object with untyped property', function () {
+    const schema = {
+      type: 'object',
+      properties: {
+        anObjectProp: {
+          type: 'object',
+          properties: {
+            aNestedProp: {
+            },
+            anotherNestedProp: {
+              type: 'number'
+            }
+          }
+        }
+      }
+    }
+    const expected = `/**
+ * @typedef {object}
+ * @property {object} [anObjectProp]
+ * @property {aNestedProp} [anObjectProp.aNestedProp]
+ * @property {number} [anObjectProp.anotherNestedProp]
+ */
+`
+    expect(generate(schema, {
+      propertyNameAsType: true
+    })).toEqual(expected)
+  })
+})
+
+describe('option: `capitalizeProperty`', function () {
+  it('Object with untyped property', function () {
+    const schema = {
+      type: 'object',
+      properties: {
+        anObjectProp: {
+          type: 'object',
+          properties: {
+            aNestedProp: {
+            },
+            anotherNestedProp: {
+              type: 'number'
+            }
+          }
+        }
+      }
+    }
+    const expected = `/**
+ * @typedef {object}
+ * @property {object} [anObjectProp]
+ * @property {ANestedProp} [anObjectProp.aNestedProp]
+ * @property {number} [anObjectProp.anotherNestedProp]
+ */
+`
+    expect(generate(schema, {
+      propertyNameAsType: true,
+      capitalizeProperty: true
+    })).toEqual(expected)
+  })
+})
+
 describe('option: `capitalizeTitle`', () => {
   it('Simple object with title and `capitalizeTitle`: true', function () {
     const schema = {
@@ -663,6 +724,64 @@ describe('option: `ignore`', () => {
 `
     expect(generate(schema, {
       ignore: ['anObjectProp']
+    })).toEqual(expected)
+  })
+})
+
+describe('option `defaultPropertyType`', function () {
+  it('Object with untyped property and "JSON" `defaultPropertyType`', function () {
+    const schema = {
+      type: 'object',
+      properties: {
+        anObjectProp: {
+          type: 'object',
+          properties: {
+            aNestedProp: {
+            },
+            anotherNestedProp: {
+              type: 'number'
+            }
+          }
+        }
+      }
+    }
+    const expected = `/**
+ * @typedef {object}
+ * @property {object} [anObjectProp]
+ * @property {JSON} [anObjectProp.aNestedProp]
+ * @property {number} [anObjectProp.anotherNestedProp]
+ */
+`
+    expect(generate(schema, {
+      defaultPropertyType: 'JSON'
+    })).toEqual(expected)
+  })
+
+  it('Object with untyped property and `false` `defaultPropertyType`', function () {
+    const schema = {
+      type: 'object',
+      properties: {
+        anObjectProp: {
+          type: 'object',
+          properties: {
+            aNestedProp: {
+            },
+            anotherNestedProp: {
+              type: 'number'
+            }
+          }
+        }
+      }
+    }
+    const expected = `/**
+ * @typedef {object}
+ * @property {object} [anObjectProp]
+ * @property [anObjectProp.aNestedProp]
+ * @property {number} [anObjectProp.anotherNestedProp]
+ */
+`
+    expect(generate(schema, {
+      defaultPropertyType: false
     })).toEqual(expected)
   })
 })


### PR DESCRIPTION
- breaking change: Have property type default to `*` for empty property type (as with arrays)
- feat: Add `anyType`, `capitalizeProperty`, `propertyAsType` options (to control property display)