### PR TITLE
Max length

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,42 @@ function getDefaultPropertyType ({
   return defaultPropertyType || fallbackPropertyType
 }
 
+function wrapDescription (options, outerIndent, description) {
+  const { maxLength } = options
+  if (!maxLength) {
+    return [description]
+  }
+  const result = []
+
+  const asteriskAndWhitespaceLength = 3 // ' * '
+  const indentMaxDelta = maxLength - outerIndent.length -
+    asteriskAndWhitespaceLength
+
+  while (true) {
+    const excess = description.length - indentMaxDelta
+    if (excess <= 0) {
+      if (description) {
+        result.push(description)
+      }
+      break
+    }
+    const maxLine = description.slice(0, indentMaxDelta)
+    const wsIndex = maxLine.search(/\s\S*$/)
+    let safeString
+    if (wsIndex === -1) {
+      // With this being all non-whitespace, e.g., a long link, we
+      //  let it go on without wrapping until whitespace is reached
+      const remainder = description.slice(indentMaxDelta).match(/^\S+/)
+      safeString = maxLine + (remainder || '')
+    } else {
+      safeString = maxLine.slice(0, wsIndex)
+    }
+    result.push(safeString)
+    description = description.slice(safeString.length + 1)
+  }
+  return result
+}
+
 module.exports = generate
 
 function generate (schema, options = {}) {
@@ -24,23 +60,24 @@ function generate (schema, options = {}) {
     return ''
   }
 
-  jsdoc.push(...writeDescription(schema, options))
+  const outerIndent = indent(options)
+  jsdoc.push(...writeDescription(schema, outerIndent, options))
 
   if (json.has(schema, '/properties')) {
-    jsdoc.push(...processProperties(schema, schema, null, options))
+    jsdoc.push(...processProperties(schema, schema, null, outerIndent, options))
   }
   if (json.has(schema, '/items')) {
-    jsdoc.push(...processItems(schema, schema, null, options))
+    jsdoc.push(...processItems(schema, schema, null, outerIndent, options))
   }
 
-  return format(jsdoc, options)
+  return format(outerIndent, jsdoc)
 }
 
 function indent (options) {
   return (options.indentChar || ' ').repeat(options.indent || 0)
 }
 
-function processItems (schema, rootSchema, base, options) {
+function processItems (schema, rootSchema, base, outerIndent, options) {
   const items = json.get(schema, '/items')
   if (!Array.isArray(items)) {
     return []
@@ -51,20 +88,20 @@ function processItems (schema, rootSchema, base, options) {
     const prefixedProperty = root + i
     const defaultValue = item.default
     if (item.type === 'array' && item.items) {
-      result.push(writeProperty('array', prefixedProperty, item.description, false, defaultValue, options))
-      result.push(...processItems(item, rootSchema, prefixedProperty, options))
+      result.push(...writeProperty('array', prefixedProperty, outerIndent, item.description, false, defaultValue, options))
+      result.push(...processItems(item, rootSchema, prefixedProperty, outerIndent, options))
     } else if (item.type === 'object' && item.properties) {
-      result.push(writeProperty('object', prefixedProperty, item.description, false, defaultValue, options))
-      result.push(...processProperties(item, rootSchema, prefixedProperty, options))
+      result.push(...writeProperty('object', prefixedProperty, outerIndent, item.description, false, defaultValue, options))
+      result.push(...processProperties(item, rootSchema, prefixedProperty, outerIndent, options))
     } else {
       const type = getType(item, rootSchema) || getDefaultPropertyType(options)
-      result.push(writeProperty(type, prefixedProperty, item.description, false, defaultValue, options))
+      result.push(...writeProperty(type, prefixedProperty, outerIndent, item.description, false, defaultValue, options))
     }
   })
   return result
 }
 
-function processProperties (schema, rootSchema, base, options) {
+function processProperties (schema, rootSchema, base, outerIndent, options) {
   const props = json.get(schema, '/properties')
   const required = json.has(schema, '/required') ? json.get(schema, '/required') : []
   const result = []
@@ -78,23 +115,24 @@ function processProperties (schema, rootSchema, base, options) {
       const prefixedProperty = root + property
       const defaultValue = props[property].default
       if (prop.type === 'object' && prop.properties) {
-        result.push(writeProperty('object', prefixedProperty, prop.description, true, defaultValue, options))
-        result.push(...processProperties(prop, rootSchema, prefixedProperty, options))
+        result.push(...writeProperty('object', prefixedProperty, outerIndent, prop.description, true, defaultValue, options))
+        result.push(...processProperties(prop, rootSchema, prefixedProperty, outerIndent, options))
       } else if (prop.type === 'array' && prop.items) {
-        result.push(writeProperty('array', prefixedProperty, prop.description, true, defaultValue, options))
-        result.push(...processItems(prop, rootSchema, prefixedProperty, options))
+        result.push(...writeProperty('array', prefixedProperty, outerIndent, prop.description, true, defaultValue, options))
+        result.push(...processItems(prop, rootSchema, prefixedProperty, outerIndent, options))
       } else {
         const optional = !required.includes(property)
         const type = getType(prop, rootSchema) || getDefaultPropertyType(options, property)
-        result.push(writeProperty(type, prefixedProperty, prop.description, optional, defaultValue, options))
+        result.push(...writeProperty(type, prefixedProperty, outerIndent, prop.description, optional, defaultValue, options))
       }
     }
   }
   return result
 }
 
-function writeDescription (schema, options) {
+function writeDescription (schema, outerIndent, options) {
   const result = []
+  const { objectTagName = 'typedef' } = options
   let { description } = schema
   if (description === undefined) {
     description = options.autoDescribe ? generateDescription(schema.title, schema.type) : ''
@@ -113,16 +151,16 @@ function writeDescription (schema, options) {
   }
 
   if (description || options.addDescriptionLineBreak) {
-    result.push(description)
+    result.push(...wrapDescription(options, outerIndent, description))
   }
 
   const namepath = schema.title ? ` ${options.capitalizeTitle ? upperFirst(schema.title) : schema.title}` : ''
-  result.push(`@${options.objectTagName || 'typedef'}${type}${namepath}`)
+  result.push(`@${objectTagName}${type}${namepath}`)
 
   return result
 }
 
-function writeProperty (type, field, description = '', optional, defaultValue, options) {
+function writeProperty (type, field, outerIndent, description = '', optional, defaultValue, options) {
   let fieldTemplate
   if (optional) {
     fieldTemplate = `[${field}${defaultValue === undefined ? '' : `=${JSON.stringify(defaultValue)}`}]`
@@ -139,7 +177,7 @@ function writeProperty (type, field, description = '', optional, defaultValue, o
     desc = ` ${description}`
   }
   const typeExpression = type === null ? '' : `{${type}} `
-  return `@property ${typeExpression}${fieldTemplate}${desc}`
+  return wrapDescription(options, outerIndent, `@property ${typeExpression}${fieldTemplate}${desc}`)
 }
 
 function getType (schema, rootSchema) {
@@ -174,12 +212,11 @@ function generateDescription (title, type) {
   return `Represents ${article} ${noun}`
 }
 
-function format (lines, options) {
-  const prefix = indent(options)
-  const result = [`${prefix}/**`]
+function format (outerIndent, lines) {
+  const result = [`${outerIndent}/**`]
 
-  result.push(...lines.map(line => line ? `${prefix} * ${line}` : ' *'))
-  result.push(`${prefix} */\n`)
+  result.push(...lines.map(line => line ? `${outerIndent} * ${line}` : ' *'))
+  result.push(`${outerIndent} */\n`)
 
   return result.join('\n')
 }

--- a/readme.md
+++ b/readme.md
@@ -103,7 +103,7 @@ jsdoc(schema, {
 - `capitalizeProperty: boolean` - When `propertyNameAsType` is `true`,
     capitalizes the property-as-type, i.e., `MyTitle` in
     `@property {MyTitle} myTitle`. Defaults to `false.`
-- `defaultPropertyType: string|null` - Used when no schema type is present.
+- `defaultPropertyType: null|string` - Used when no schema type is present.
     If set to a string, that string will be used (e.g., "any", "JSON",
     "external:JSON"). Note that jsdoc recommends `*` for any, while TypeScript
     uses "any". If one defines one's own "JSON" type, one could use that to
@@ -128,6 +128,9 @@ jsdoc(schema, {
     the indent for every line of the document block after the first.
 - `indentChar: string` - Character to use when `indent` is set (e.g., a tab or
     space). Defaults to a space.
+- `maxLength: number|boolean` - Enforce a maximum length in `@typedef` and
+    `@property` descriptions (taking into account `indent`/`indentChar`).
+    Set to `false` to prevent wrapping entirely. Defaults to `false`.
 - `objectTagName: string` - Tag name to use for objects. Defaults to `typedef`.
 - `propertyNameAsType: boolean` -  Indicates that the property name (for
     objects) should be used as the type name (optionally capitalized with

--- a/test.js
+++ b/test.js
@@ -785,3 +785,63 @@ describe('option `defaultPropertyType`', function () {
     })).toEqual(expected)
   })
 })
+
+describe('option: `maxLength`', () => {
+  it('Simple object with description and `maxLength`', function () {
+    const schema = {
+      type: 'object',
+      properties: {
+        aShortStringProp: {
+          description: 'A short description',
+          type: 'string'
+        },
+        aStringProp: {
+          description: 'This is a very, very, very, very, very, very, very, very, very, very, very long description on the property.',
+          type: 'string'
+        },
+        aNonBreakingStringProp: {
+          description: 'https://example.com/a/very/very/very/very/very/very/very/very/long/nonbreaking/string',
+          type: 'string'
+        },
+        aLongStringBreakingAtEnd: {
+          description: 'https://example.com/another/very/very/very/very/very/very/very/lng/string breaking at end',
+          type: 'string'
+        }
+      },
+      description: 'This is a very, very, very, very, very, very, very, very, very, very, very long description.'
+    }
+    const indent = '    '
+    const expected = `${indent}/**
+${indent} * This is a very, very, very, very, very, very, very, very, very, very,
+${indent} * very long description.
+${indent} * @typedef {object}
+${indent} * @property {string} [aShortStringProp] A short description
+${indent} * @property {string} [aStringProp] This is a very, very, very, very, very,
+${indent} * very, very, very, very, very, very long description on the property.
+${indent} * @property {string} [aNonBreakingStringProp]
+${indent} * https://example.com/a/very/very/very/very/very/very/very/very/long/nonbreaking/string
+${indent} * @property {string} [aLongStringBreakingAtEnd]
+${indent} * https://example.com/another/very/very/very/very/very/very/very/lng/string
+${indent} * breaking at end
+${indent} */
+`
+    expect(generate(schema, {
+      indent: 4,
+      maxLength: 80
+    })).toEqual(expected)
+
+    const expectedNowrapping = `${indent}/**
+${indent} * This is a very, very, very, very, very, very, very, very, very, very, very long description.
+${indent} * @typedef {object}
+${indent} * @property {string} [aShortStringProp] A short description
+${indent} * @property {string} [aStringProp] This is a very, very, very, very, very, very, very, very, very, very, very long description on the property.
+${indent} * @property {string} [aNonBreakingStringProp] https://example.com/a/very/very/very/very/very/very/very/very/long/nonbreaking/string
+${indent} * @property {string} [aLongStringBreakingAtEnd] https://example.com/another/very/very/very/very/very/very/very/lng/string breaking at end
+${indent} */
+`
+
+    expect(generate(schema, {
+      indent: 4
+    })).toEqual(expectedNowrapping)
+  })
+})


### PR DESCRIPTION
Builds on #28. Fixes #6.

- `maxLength`: Wrap descriptions on description and `property` to number
    of characters unless set to `false` (the default)

(The `@typedef` line should not need wrapping since it should only have a namepath (no description), and this should not have spaces and thus it should not be expected to wrap (if the `title` has spaces, it would be up to the user to change it to become valid).)