### PR TITLE
Enums

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ function writeDescription (schema, config) {
     type = ` {${
       typeMatch === ''
         ? ''
-        : typeMatch || schema.type
+        : typeMatch || getType(schema, schema)
       }}`
   }
 
@@ -190,6 +190,9 @@ function getType (schema, rootSchema) {
   }
 
   if (schema.enum) {
+    if (schema.type === 'string') {
+      return `"${schema.enum.join('"|"')}"`
+    }
     return 'enum'
   }
 

--- a/test.js
+++ b/test.js
@@ -43,6 +43,18 @@ describe('Simple schemas', () => {
     expect(generate(schema)).toEqual(expected)
   })
 
+  it('String with enum', function () {
+    const schema = {
+      type: 'string',
+      enum: ['some', 'different', 'types']
+    }
+    const expected = `/**
+ * @typedef {"some"|"different"|"types"}
+ */
+`
+    expect(generate(schema)).toEqual(expected)
+  })
+
   it('Simple array with title', function () {
     const schema = {
       title: 'special',
@@ -112,6 +124,10 @@ describe('Schemas with properties', () => {
         },
         enumProp: {
           enum: ['hello', 'world']
+        },
+        enumStringProp: {
+          type: 'string',
+          enum: ['hello', 'there', 'world']
         }
       }
     }
@@ -125,6 +141,7 @@ describe('Schemas with properties', () => {
  * @property {?string} [nullableType]
  * @property {string|number} [multipleTypes]
  * @property {enum} [enumProp]
+ * @property {"hello"|"there"|"world"} [enumStringProp]
  */
 `
     expect(generate(schema)).toEqual(expected)


### PR DESCRIPTION
- feat: Handle string enums as string literals
- feat: process root for non-object/non-array types (nullable, multiple types)

Btw, I took a look at other forks to look for anything that might be useful. This looks like the one fork with some useful ideas (like a CLI) that might be nice to include (not on my priority list, but just an FYI): https://github.com/n3ps/json-schema-to-jsdoc/compare/master...cdmgtri:dev