### PR TITLE
Use `minItems` or lack to determine optionality for array items

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,15 +94,16 @@ function processItems (schema, rootSchema, base, config) {
     const root = base ? `${base}.` : ''
     const prefixedProperty = root + i
     const defaultValue = item.default
+    const optional = !schema.minItems || i >= schema.minItems
     if (item.type === 'array' && item.items) {
-      result.push(...writeProperty('array', prefixedProperty, item.description, false, defaultValue, config))
+      result.push(...writeProperty('array', prefixedProperty, item.description, optional, defaultValue, config))
       result.push(...processItems(item, rootSchema, prefixedProperty, config))
     } else if (item.type === 'object' && item.properties) {
-      result.push(...writeProperty('object', prefixedProperty, item.description, false, defaultValue, config))
+      result.push(...writeProperty('object', prefixedProperty, item.description, optional, defaultValue, config))
       result.push(...processProperties(item, rootSchema, prefixedProperty, config))
     } else {
       const type = getType(item, rootSchema) || getDefaultPropertyType(config)
-      result.push(...writeProperty(type, prefixedProperty, item.description, false, defaultValue, config))
+      result.push(...writeProperty(type, prefixedProperty, item.description, optional, defaultValue, config))
     }
   })
   return result

--- a/test.js
+++ b/test.js
@@ -167,6 +167,7 @@ describe('Schemas with properties', () => {
             aNestedArrayProp: {
               description: 'Array desc.',
               type: 'array',
+              minItems: 1,
               items: [
                 {
                   type: 'number'
@@ -357,6 +358,7 @@ describe('Schemas with items', function () {
         }
       },
       type: 'array',
+      minItems: 1,
       items: [{
         $ref: '#/$defs/definitionType'
       }]
@@ -391,6 +393,7 @@ describe('Schemas with items', function () {
   it('Array with items', function () {
     const schema = {
       type: 'array',
+      minItems: 3,
       items: [
         {
           type: 'string'
@@ -421,8 +424,8 @@ describe('Schemas with items', function () {
  * @property {object} 1
  * @property {boolean} [1.aNestedProp] Boolean desc.
  * @property {?string} 2
- * @property {string|number} 3
- * @property {enum} 4
+ * @property {string|number} [3]
+ * @property {enum} [4]
  */
 `
     expect(generate(schema)).toEqual(expected)
@@ -431,9 +434,11 @@ describe('Schemas with items', function () {
   it('Array with untyped property', function () {
     const schema = {
       type: 'array',
+      minItems: 1,
       items: [
         {
           type: 'array',
+          minItems: 2,
           items: [
             {
             },

--- a/test.js
+++ b/test.js
@@ -415,6 +415,10 @@ describe('Schemas with items', function () {
         },
         {
           enum: ['hello', 'world']
+        },
+        {
+          type: 'string',
+          default: 'hello'
         }
       ]
     }
@@ -426,6 +430,7 @@ describe('Schemas with items', function () {
  * @property {?string} 2
  * @property {string|number} [3]
  * @property {enum} [4]
+ * @property {string} [5="hello"]
  */
 `
     expect(generate(schema)).toEqual(expected)


### PR DESCRIPTION
- Breaking enhancement: expect `minItems` for required array items; default to array items being optional

The prior behavior was that array items would all be marked as required (note that the JSON Schema `required` property expects *property* names, as with object names, not array indexes, so it can't be used with array items).

But the behavior with this PR is to use `minItems` (whose [default is 0](https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.6.4.2)), such that an item will only be required if it has an index less than `minItems` (so to get required array items, you now need `minItems`).